### PR TITLE
Add primitive virtualenv settings.

### DIFF
--- a/lib/acp-python-jedi.coffee
+++ b/lib/acp-python-jedi.coffee
@@ -31,6 +31,11 @@ module.exports =
       default: true
       title: "Complete Arguments for Functions"
       description: "This will cause the suggestions for functions to include their arguments."
+    directoryConfigFile:
+      type: 'string'
+      default: '.acp-python-jedi.cson'
+      title: 'Per-directory Autocomplete-Plus-Python-Jedi Config File'
+      description: "File containing information about the virtualenv to use for a given directory."
 
   provider: null
 

--- a/lib/jedi-provider.coffee
+++ b/lib/jedi-provider.coffee
@@ -29,21 +29,25 @@ class JediProvider
 		# TODO what if there are multiple paths?
 		projectPath = atom.project.getPaths()[0]
 		configFile = atom.config.get "autocomplete-plus-python-jedi.directoryConfigFile"
-		{ virtualenv } = CSON.readFileSync "#{projectPath}/#{configFile}"
-		command = "#{virtualenv.root}/bin/#{virtualenv.python_executable}"
-		@proc = spawn(command, [ __dirname + '/jedi-cmd.py', projectPath ])
+		CSON.readFile "#{projectPath}/#{configFile}", (err, data) =>
+			if (not data?) or err?
+				command = "python"
+			else
+				{ virtualenv } = data
+				command = "#{virtualenv.root}/bin/#{virtualenv.python_executable}"
 
-		@proc.on('error', (err) => @handleProcessError())
-		@proc.on('exit', (code, signal) => @handleProcessError())
+			@proc = spawn(command, [ __dirname + '/jedi-cmd.py', projectPath ])
+			@proc.on('error', (err) => @handleProcessError())
+			@proc.on('exit', (code, signal) => @handleProcessError())
 
-		@halted = false
-		@isSetUp = false
-		@reqCount = 0
-		@cbs = {}
+			@halted = false
+			@isSetUp = false
+			@reqCount = 0
+			@cbs = {}
 
-		@proc.stderr.on('data', (data) ->
-  		console.log('Jedi.py Error: ' + data);
-		)
+			@proc.stderr.on('data', (data) ->
+				console.log('Jedi.py Error: ' + data)
+			)
 
 	setUp: ->
 		@rl = readline.createInterface({

--- a/lib/jedi-provider.coffee
+++ b/lib/jedi-provider.coffee
@@ -1,5 +1,5 @@
 $ = require 'jquery'
-
+CSON = require 'season'
 spawn = require('child_process').spawn
 readline = require('readline')
 
@@ -28,8 +28,9 @@ class JediProvider
 	constructor: ->
 		# TODO what if there are multiple paths?
 		projectPath = atom.project.getPaths()[0]
-
-		command = "python"
+		configFile = atom.config.get "autocomplete-plus-python-jedi.directoryConfigFile"
+		{ virtualenv } = CSON.readFileSync "#{projectPath}/#{configFile}"
+		command = "#{virtualenv.root}/bin/#{virtualenv.python_executable}"
 		@proc = spawn(command, [ __dirname + '/jedi-cmd.py', projectPath ])
 
 		@proc.on('error', (err) => @handleProcessError())


### PR DESCRIPTION
This reads a couple of config settings from a JSON/CSON file. This is just a small start, and probably the easiest possible part, toward per-directory virtualenv config. The hard stuff I will leave to the more capable & experienced.

I can think of a billion problems with this approach I chose here, but I wanted to get something workable as maybe like a starting point or something.

Refs #12 
