### PR TITLE
Better autocomplete by supporting all visible modules

### DIFF
--- a/lib/acp-python-jedi.coffee
+++ b/lib/acp-python-jedi.coffee
@@ -31,6 +31,11 @@ module.exports =
       default: true
       title: "Complete Arguments for Functions"
       description: "This will cause the suggestions for functions to include their arguments."
+    extraPaths:
+      type: 'string'
+      default: ''
+      title: 'Extra PATH'
+      description: 'Comma separated list of modules to additionally include for autocomplete.'
 
   provider: null
 

--- a/lib/jedi-cmd.py
+++ b/lib/jedi-cmd.py
@@ -1,7 +1,6 @@
 import sys
 import json
 import time
-import inspect
 import os
 
 JEDI_IMPORT_FAILED = False
@@ -10,9 +9,7 @@ try:
   import jedi
 except ImportError:
   # Use the bundled jedi
-  my_file = inspect.stack()[0][1]
-  my_path = os.path.dirname(os.path.abspath(my_file))
-  sys.path.append(my_path + '/python_packages')
+  sys.path.append(os.path.join(os.path.dirname(__file__), 'python_packages'))
   try:
     import jedi
   except ImportError:

--- a/lib/jedi-cmd.py
+++ b/lib/jedi-cmd.py
@@ -4,100 +4,122 @@ import time
 import inspect
 import os
 
-JEDI_IMPORT_FAILED=False
+JEDI_IMPORT_FAILED = False
 
 try:
-	import jedi
+  import jedi
 except ImportError:
-	# Use the bundled jedi
-	my_file = inspect.stack()[0][1]
-	my_path = os.path.dirname(os.path.abspath(my_file))
-	sys.path.append(my_path + '/python_packages')
-	try:
-		import jedi
-	except ImportError:
-		JEDI_IMPORT_FAILED=True
+  # Use the bundled jedi
+  my_file = inspect.stack()[0][1]
+  my_path = os.path.dirname(os.path.abspath(my_file))
+  sys.path.append(my_path + '/python_packages')
+  try:
+    import jedi
+  except ImportError:
+    JEDI_IMPORT_FAILED = True
+
 
 class JediCmdline(object):
-	def __init__(self, istream, ostream):
-		self.istream = istream
-		self.ostream = ostream
+  def __init__(self, istream, ostream):
+    self.istream = istream
+    self.ostream = ostream
 
-	def _get_params(self, completion):
-		try:
-			param_defs = completion.params
-		except AttributeError:
-			return []
-		except:
-			# TODO Propagate!
-			return []
+  def _get_params(self, completion):
+    try:
+      param_defs = completion.params
+    except AttributeError:
+      return []
+    except:
+      # TODO Propagate!
+      return []
 
-		params = []
-		for param_def in param_defs:
-			params.append({
-				'name': param_def.name,
-				'description': param_def.description
-			})
+    params = []
+    for param_def in param_defs:
+      params.append({
+        'name': param_def.name,
+        'description': param_def.description
+      })
 
-		return params
+    return params
 
-	def _process_line(self, line):
-		data =  json.loads(line)
-		script = jedi.api.Script(data['source'], data['line'] + 1, data['column'])
+  @classmethod
+  def _get_top_level_module(cls, path):
+    """Recursively walk through directories looking for top level module.
+    """
+    _path, _ = os.path.split(path)
+    if os.path.isfile(os.path.join(_path, '__init__.py')):
+      return cls._get_top_level_module(_path)
+    return path
 
-		retData = []
-		try:
-			completions = script.completions()
+  def _process_line(self, line):
+    """
+    Jedi will use filepath to look for another modules at same path,
+    but it will not be able to see modules **above**, so our goal
+    is to find the higher python module available from filepath.
+    """
+    data = json.loads(line)
 
-			for completion in completions:
-				params = self._get_params(completion)
+    path = self._get_top_level_module(data.get('path', ''))
+    if path not in sys.path:
+      sys.path.insert(0, path)
+    script = jedi.api.Script(
+      source=data['source'], line=data['line'] + 1, column=data['column'],
+      path=data.get('path', ''))
 
-				retData.append({
-					'name': completion.name,
-					'complete': completion.complete,
-					'description': completion.description,
-					'type': completion.type,
-					'params': params,
-					'docstring': completion.docstring()
-				})
-		except:
-			# TODO Error handling!
-			pass
+    retData = []
+    try:
+      completions = script.completions()
 
-		self._write_response(retData, data)
+      for completion in completions:
+        params = self._get_params(completion)
 
-	def _write_response(self, retData, data):
-		reqId = data['reqId']
-		ret = {'reqId': reqId,
-				'prefix': data['prefix'],
-				'suggestions': retData}
-		self.ostream.write(json.dumps(ret) + "\n")
-		self.ostream.flush()
+        retData.append({
+          'name': completion.name,
+          'complete': completion.complete,
+          'description': completion.description,
+          'type': completion.type,
+          'params': params,
+          'docstring': completion.docstring(),
+          '_data': data,
+          '_path': sys.path,
+        })
+    except:
+      # TODO Error handling!
+      pass
 
-	def _write_msg(self, code):
-		ret = {'reqId': 'msg',
-				'msg': code,
-				'halt': True}
-		self.ostream.write(json.dumps(ret) + "\n")
-		self.ostream.flush()
+    self._write_response(retData, data)
 
-	def _watch(self):
-		# This seems to be the only sane way for python 2 and 3...
-		while True:
-			line = self.istream.readline()
-			self._process_line(line)
+  def _write_response(self, retData, data):
+    reqId = data['reqId']
+    ret = {'reqId': reqId, 'prefix': data['prefix'], 'suggestions': retData}
+    self.ostream.write(json.dumps(ret) + "\n")
+    self.ostream.flush()
 
-	def run(self):
-		if JEDI_IMPORT_FAILED:
-			self._write_msg('jedi-missing')
-			while True:
-				time.sleep(10)
+  def _write_msg(self, code):
+    ret = {'reqId': 'msg', 'msg': code, 'halt': True}
+    self.ostream.write(json.dumps(ret) + '\n')
+    self.ostream.flush()
 
-		self._watch()
+  def _watch(self):
+    # This seems to be the only sane way for python 2 and 3...
+    while True:
+      line = self.istream.readline()
+      self._process_line(line)
+
+  def run(self):
+    if JEDI_IMPORT_FAILED:
+      self._write_msg('jedi-missing')
+      while True:
+        time.sleep(10)
+
+    self._watch()
 
 if __name__ == '__main__':
-	project_path = sys.argv[1]
-	sys.path.append(project_path)
+  # TODO: jedi is not inderested in folders which are not python modules
+  # (are not contains __init__.py file)
+  for path in sys.argv[1:]:
+    if path not in sys.path:
+      sys.path.insert(0, path)
 
-	cmdline = JediCmdline(sys.stdin, sys.stdout)
-	cmdline.run()
+  cmdline = JediCmdline(sys.stdin, sys.stdout)
+  cmdline.run()

--- a/lib/jedi-cmd.py
+++ b/lib/jedi-cmd.py
@@ -80,8 +80,6 @@ class JediCmdline(object):
           'type': completion.type,
           'params': params,
           'docstring': completion.docstring(),
-          '_data': data,
-          '_path': sys.path,
         })
     except:
       # TODO Error handling!

--- a/lib/jedi-provider.coffee
+++ b/lib/jedi-provider.coffee
@@ -27,9 +27,12 @@ class JediProvider
 
 	constructor: ->
 		projectPaths = atom.project.getPaths()
+		extraPaths = atom.config.get('autocomplete-plus-python-jedi.extraPaths')
+		extraPaths = (p for p in extraPaths.split(',') when p)
+		paths = projectPaths.concat(extraPaths)
 
 		command = "python"
-		@proc = spawn(command, [ __dirname + '/jedi-cmd.py'].concat(projectPaths))
+		@proc = spawn(command, [ __dirname + '/jedi-cmd.py'].concat(paths))
 
 		@proc.on('error', (err) => @handleProcessError())
 		@proc.on('exit', (code, signal) => @handleProcessError())

--- a/lib/jedi-provider.coffee
+++ b/lib/jedi-provider.coffee
@@ -85,6 +85,8 @@ class JediProvider
 
 		suggestions = []
 		for suggestionData in data['suggestions']
+			if prefix == '.'
+				prefix = ''
 			wholeText = prefix + suggestionData['complete']
 
 			# TODO watch this

--- a/lib/jedi-provider.coffee
+++ b/lib/jedi-provider.coffee
@@ -26,11 +26,10 @@ class JediProvider
 			@rl.close()
 
 	constructor: ->
-		# TODO what if there are multiple paths?
-		projectPath = atom.project.getPaths()[0]
+		projectPaths = atom.project.getPaths()
 
 		command = "python"
-		@proc = spawn(command, [ __dirname + '/jedi-cmd.py', projectPath ])
+		@proc = spawn(command, [ __dirname + '/jedi-cmd.py'].concat(projectPaths))
 
 		@proc.on('error', (err) => @handleProcessError())
 		@proc.on('exit', (code, signal) => @handleProcessError())
@@ -149,6 +148,7 @@ class JediProvider
 		payload =
 			reqId: reqId
 			prefix: prefix
+			path: editor.getPath()
 			source: editor.getText()
 			line: bufferPosition.row
 			column: bufferPosition.column


### PR DESCRIPTION
- Handle all python modules which are visible to file you are currently editing.
- Replace tabs with spaces in python code as tabs are forbidden by PEP8.
- Handle multiple folder projects (but its useless if project folder is not a python module, see TODO comment)
